### PR TITLE
bgpd: Fix memory leak bgp show command

### DIFF
--- a/bgpd/bgp_route.c
+++ b/bgpd/bgp_route.c
@@ -8202,7 +8202,6 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 			vty_out(vty, " \"routeDistinguishers\" : {");
 			++*json_header_depth;
 		}
-		json_paths = json_object_new_object();
 	}
 
 	if (use_json && rd) {
@@ -8429,8 +8428,6 @@ static int bgp_show_table(struct vty *vty, struct bgp *bgp, safi_t safi,
 		*total_cum = total_count;
 	}
 	if (use_json) {
-		if (json_paths)
-			json_object_free(json_paths);
 		if (rd) {
 			vty_out(vty, " }%s ", (is_last ? "" : ","));
 		}


### PR DESCRIPTION
Root Cause: In the function bgp_show_table(), we are creating a
json object and a json array with the same name as “json_paths”.
First it will create a json object variable "json_paths" pointing
to the memory allocated for the json object. Then it will create
a json array for each bap node rn (if rn->info is available) with
the same name as json_paths. Because of this, json_paths which was
pointing to the memory allocated for the json object earlier, now
will be overwritten with the memory allocated for the json array.
As per the existing code, at the end of each iteration loop of bgp
node, it will deallocate the memory used by the json array and
assigned NULL to the variable json_paths. Since we don’t have the
pointer pointing to the memory allocated for json object, will be
not able to de-allocate the memory, which is a memory leak here.

Fix: Removing this json object since it is never getting used in
this function.

Signed-off-by: Sarita Patra <saritap@vmware.com>