### PR TITLE
pimd: create a new command ip pim

### DIFF
--- a/pimd/pim_cmd.c
+++ b/pimd/pim_cmd.c
@@ -6431,7 +6431,7 @@ DEFUN_HIDDEN (interface_ip_pim_ssm,
 	return CMD_SUCCESS;
 }
 
-DEFUN (interface_ip_pim_sm,
+DEFUN_HIDDEN (interface_ip_pim_sm,
        interface_ip_pim_sm_cmd,
        "ip pim sm",
        IP_STR
@@ -6451,6 +6451,27 @@ DEFUN (interface_ip_pim_sm,
 	pim_if_create_pimreg(pim_ifp->pim);
 
 	return CMD_SUCCESS;
+}
+
+DEFUN (interface_ip_pim,
+       interface_ip_pim_cmd,
+       "ip pim",
+       IP_STR
+       PIM_STR)
+{
+        struct pim_interface *pim_ifp;
+
+        VTY_DECLVAR_CONTEXT(interface, ifp);
+        if (!pim_cmd_interface_add(ifp)) {
+                vty_out(vty, "Could not enable PIM SM on interface\n");
+                return CMD_WARNING_CONFIG_FAILED;
+        }
+
+        pim_ifp = ifp->info;
+
+        pim_if_create_pimreg(pim_ifp->pim);
+
+        return CMD_SUCCESS;
 }
 
 static int pim_cmd_interface_delete(struct interface *ifp)
@@ -6495,7 +6516,7 @@ DEFUN_HIDDEN (interface_no_ip_pim_ssm,
 	return CMD_SUCCESS;
 }
 
-DEFUN (interface_no_ip_pim_sm,
+DEFUN_HIDDEN (interface_no_ip_pim_sm,
        interface_no_ip_pim_sm_cmd,
        "no ip pim sm",
        NO_STR
@@ -6510,6 +6531,22 @@ DEFUN (interface_no_ip_pim_sm,
 	}
 
 	return CMD_SUCCESS;
+}
+
+DEFUN (interface_no_ip_pim,
+       interface_no_ip_pim_cmd,
+       "no ip pim",
+       NO_STR
+       IP_STR
+       PIM_STR)
+{
+        VTY_DECLVAR_CONTEXT(interface, ifp);
+        if (!pim_cmd_interface_delete(ifp)) {
+                vty_out(vty, "Unable to delete interface information\n");
+                return CMD_WARNING_CONFIG_FAILED;
+        }
+
+        return CMD_SUCCESS;
 }
 
 /* boundaries */
@@ -7466,7 +7503,7 @@ DEFUN (interface_pim_use_source,
        interface_pim_use_source_cmd,
        "ip pim use-source A.B.C.D",
        IP_STR
-       "pim multicast routing\n"
+       PIM_STR
        "Configure primary IP address\n"
        "source ip address\n")
 {
@@ -7478,7 +7515,7 @@ DEFUN (interface_no_pim_use_source,
        "no ip pim use-source [A.B.C.D]",
        NO_STR
        IP_STR
-       "pim multicast routing\n"
+       PIM_STR
        "Delete source IP address\n"
        "source ip address\n")
 {
@@ -8634,8 +8671,6 @@ void pim_cmd_init(void)
 
 	install_node(&debug_node, pim_debug_config_write);
 
-	install_element(CONFIG_NODE, &ip_multicast_routing_cmd);
-	install_element(CONFIG_NODE, &no_ip_multicast_routing_cmd);
 	install_element(CONFIG_NODE, &ip_pim_rp_cmd);
 	install_element(VRF_NODE, &ip_pim_rp_cmd);
 	install_element(CONFIG_NODE, &no_ip_pim_rp_cmd);
@@ -8721,6 +8756,8 @@ void pim_cmd_init(void)
 	install_element(INTERFACE_NODE, &interface_no_ip_pim_ssm_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_pim_sm_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ip_pim_sm_cmd);
+	install_element(INTERFACE_NODE, &interface_ip_pim_cmd);
+        install_element(INTERFACE_NODE, &interface_no_ip_pim_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_pim_drprio_cmd);
 	install_element(INTERFACE_NODE, &interface_no_ip_pim_drprio_cmd);
 	install_element(INTERFACE_NODE, &interface_ip_pim_hello_cmd);


### PR DESCRIPTION
A new command "ip pim" is created which replaces the existing commands
"ip pim sm" and "ip pim ssm" and make "ip pim sm" and "ip pim ssm" as
hidden commands. The command "ip multicast-routing" is removed since
it is already enabled on FRR by default.

Signed-off-by: Sarita Patra saritap@vmware.com